### PR TITLE
alc and gex header fix

### DIFF
--- a/libaarhusxyz/alc.py
+++ b/libaarhusxyz/alc.py
@@ -15,7 +15,15 @@ def parse(nameorfile, xyz_columns=None):
     return {"meta": meta,
             "mapping": mapping}
 
-supported_fields = ["Date","Line","Magnetic","Misc1 ","Misc2","Misc3","Misc4","PowerLineMonitor","RxPitch","RxRoll","Time","Topography","TxAltitude","TxOffTime","TxOnTime","TxPeakTime","TxPitch","TxRoll","TxRxHoriSep","TxRxVertSep","UTMX","UTMY","Current_Ch01","Current_Ch02","Gate_Ch01.*","Gate_Ch02.*","STD_Ch01.*","STD_Ch02.*"]
+supported_fields = ["DateTime","Date","Time","Flight","Line","GdSpeed","Alt","DEM",
+                    "Magnetic","PowerLineMonitor",
+                    "RxPitch","RxRoll","Topography","TxAltitude",
+                    "TxOffTime","TxOnTime","TxPeakTime",
+                    "TxPitch","TxRoll","TxRxHoriSep","TxRxVertSep","UTMX","UTMY",
+                    "Current_Ch01","Current_Ch02",
+                    "Gate_Ch01.*","Gate_Ch02.*",
+                    "STD_Ch01.*","STD_Ch02.*",
+                    "InUse_Ch01.*","InUse_Ch02.*"]
 
 
 def is_supported_field(fieldname):

--- a/libaarhusxyz/alc.py
+++ b/libaarhusxyz/alc.py
@@ -17,6 +17,8 @@ def parse(nameorfile, xyz_columns=None):
 
 supported_fields = ["DateTime","Date","Time","Flight","Line","GdSpeed","Alt","DEM",
                     "Magnetic","PowerLineMonitor",
+                    "Misc1","Misc2","Misc3","Misc4",
+                    "Current_Ch01","Current_Ch02",
                     "RxPitch","RxRoll","Topography","TxAltitude",
                     "TxOffTime","TxOnTime","TxPeakTime",
                     "TxPitch","TxRoll","TxRxHoriSep","TxRxVertSep","UTMX","UTMY",
@@ -33,8 +35,20 @@ def is_supported_field(fieldname):
     return False
 
 def _dump(xyz, f, columns=None):
+    print(columns)
     if columns is None:
         columns = xyz["file_meta"]["columns"]
+    else:
+        columns_=[]
+        for column_name in columns:
+            words=re.split('\[|\]', column_name)
+            if len(words)==1:
+                columns_.append(words[0])
+            else:
+                newname="{0}_{1:02d}".format(words[0],int(words[1])+1)
+                columns_.append(newname)
+        columns=columns_
+    print(columns)
     rows = [{"canonical_name": col, "position": idx + 1}
              for idx, col in enumerate(columns)
              if is_supported_field(col)]

--- a/libaarhusxyz/alc.py
+++ b/libaarhusxyz/alc.py
@@ -35,7 +35,6 @@ def is_supported_field(fieldname):
     return False
 
 def _dump(xyz, f, columns=None):
-    print(columns)
     if columns is None:
         columns = xyz["file_meta"]["columns"]
     else:
@@ -48,11 +47,9 @@ def _dump(xyz, f, columns=None):
                 newname="{0}_{1:02d}".format(words[0],int(words[1])+1)
                 columns_.append(newname)
         columns=columns_
-    print(columns)
     rows = [{"canonical_name": col, "position": idx + 1}
              for idx, col in enumerate(columns)
              if is_supported_field(col)]
-    
     channels = set([row["canonical_name"][len("Gate_Ch"):].split("_")[0]
                     for row in rows
                     if row["canonical_name"].startswith("Gate_Ch")])

--- a/libaarhusxyz/xyz.py
+++ b/libaarhusxyz/xyz.py
@@ -142,13 +142,14 @@ def _un_split_layer_columns(data):
 
 def _dump(data, file, alcfile=None):
     df = _un_split_layer_columns(data)
-    for key, value in data['model_info'].items():
-        if key != 'source':
-            file.write("/" + str(key) + "\n")
-            if isinstance(value, list):
-                file.write("/" + ' '.join(str(item) for item in value) + "\n")
-            else:
-                file.write("/" + str(value) + "\n")
+    if alcfile==None:
+        for key, value in data['model_info'].items():
+            if key != 'source':
+                file.write("/" + str(key) + "\n")
+                if isinstance(value, list):
+                    file.write("/" + ' '.join(str(item) for item in value) + "\n")
+                else:
+                    file.write("/" + str(value) + "\n")
     file.write('/ ')
     df.to_csv(file, index=False, sep=' ', na_rep="*", encoding='utf-8')
 


### PR DESCRIPTION
Did some minor modifications, so that Aarhus Workbench can read the xyz-data and alc-file written with libaarhus.dump(...)
Might be a bit ugly but is working. Feel free to change the coding to be more "pythonic" ;-). 

Did the following modifications:
- all channel/gate related information in .alc file must end on `Gate_Ch01_45` not `Gate_Ch01_[44]`.
- the first gate channel must be numbered with 01 not 00 (like `Gate_Ch01_01` instead of `Gate_Ch01_[00]`).
- The xyz file must only have 1 header line, when input to AarhusWorkbench, so `data['model_info']` must be skipped and not written to file.