### PR TITLE
add color-limit support for profile plotting.

### DIFF
--- a/libaarhusxyz/xyz.py
+++ b/libaarhusxyz/xyz.py
@@ -393,7 +393,10 @@ class XYZ(object):
         zcoords = zcoords[:,::-1].T
         data = data[:,::-1].T
 
-        m = ax.pcolor(xcoords, zcoords, data, cmap=cmap, norm=matplotlib.colors.LogNorm(), shading=shading, **kw)
+        if 'clim' in locals():
+            m = ax.pcolor(xcoords, zcoords, data, cmap=cmap, norm=matplotlib.colors.LogNorm(vmin=clim[0], vmax=clim[1], clip=True), shading=shading, **kw)
+        else:
+            m = ax.pcolor(xcoords, zcoords, data, cmap=cmap, norm=matplotlib.colors.LogNorm(), shading=shading, **kw)
         if cax is None:
             ax_divider = mpl_toolkits.axes_grid1.axes_divider.make_axes_locatable(ax)
             cax = ax_divider.append_axes("right", size="7%", pad="2%")

--- a/libaarhusxyz/xyz.py
+++ b/libaarhusxyz/xyz.py
@@ -369,7 +369,7 @@ class XYZ(object):
         flightlines = self.flightlines.loc[filt]
         ax.plot(flightlines.xdist, flightlines[self.alt_column] + flightlines[self.z_column], label="Instrument position")
         
-    def _plot_line_resistivity(self, line_no, ax, cax=None, cmap="turbo", shading='flat', **kw):
+    def _plot_line_resistivity(self, line_no, ax, cax=None, norm=None, cmin=None, cmax=None, cmap="turbo", shading='flat', **kw):
         filt = self.flightlines[self.line_id_column] == line_no
         flightlines = self.flightlines.loc[filt]
         resistivity = self.resistivity.loc[filt]
@@ -393,10 +393,11 @@ class XYZ(object):
         zcoords = zcoords[:,::-1].T
         data = data[:,::-1].T
 
-        if 'clim' in locals():
-            m = ax.pcolor(xcoords, zcoords, data, cmap=cmap, norm=matplotlib.colors.LogNorm(vmin=clim[0], vmax=clim[1], clip=True), shading=shading, **kw)
-        else:
-            m = ax.pcolor(xcoords, zcoords, data, cmap=cmap, norm=matplotlib.colors.LogNorm(), shading=shading, **kw)
+        if norm is None:
+            norm = matplotlib.colors.LogNorm(vmin=cmin, vmax=cmax, clip=True)
+
+        m = ax.pcolor(xcoords, zcoords, data, cmap=cmap, norm=norm, shading=shading, **kw)
+
         if cax is None:
             ax_divider = mpl_toolkits.axes_grid1.axes_divider.make_axes_locatable(ax)
             cax = ax_divider.append_axes("right", size="7%", pad="2%")


### PR DESCRIPTION
I added support for passing either a matplotlib 'norm' or 'cmin' (mpl-norm's vmin) or 'cmax' (mpl-norm's vmax) to be passed to a resistivity profile.