### PR TITLE
Migrate off pkg_resources to importlib (v0.0.45)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.0.45
+
+### Changed
+- Migrate off `pkg_resources` (removed in setuptools 81) to `importlib.resources`
+  for loading bundled `normalizer.csv` / `normalizer_pattern.csv`.
+
+### Fixed (unreleased on PyPI since 0.0.44)
+- Fallback on `NumberOfTurns` when the key does not exist.
+- GEX: handle empty values in the parse/dump round-trip.
+- Fix `layer_params` property crash on an incomplete `model_dict`.
+- Fix `apply_diff` and `model_info` for sparse diff objects.
+- Fix `dict2dfs` handling of `None` values in msgpack diff `layer_data`.
+
 ## 2026-01-29
 
 ### Added case-insensitive column name detection in `xyz.py`

--- a/libaarhusxyz/normalizer.py
+++ b/libaarhusxyz/normalizer.py
@@ -4,12 +4,12 @@ import pyproj
 import re
 import datetime
 import csv
-import pkg_resources
+from importlib.resources import files
 
 def _read_csv(f):
     return pd.read_csv(f)
 
-with pkg_resources.resource_stream("libaarhusxyz", "normalizer.csv") as f:
+with files("libaarhusxyz").joinpath("normalizer.csv").open("rb") as f:
     name_mapping = _read_csv(f)
 
 def complete_name_mapping(name_mapping):
@@ -25,7 +25,7 @@ def complete_name_mapping(name_mapping):
 
 complete_name_mapping(name_mapping)
     
-with pkg_resources.resource_stream("libaarhusxyz", "normalizer_pattern.csv") as f:
+with files("libaarhusxyz").joinpath("normalizer_pattern.csv").open("rb") as f:
     name_mapping_patterns = _read_csv(f)
 
 def map_name_pattern(value):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 
 setuptools.setup(
     name='libaarhusxyz',
-    version='0.0.33.3',
+    version='0.0.45',
     description='Parser for the Aarhus Workbench XYZ format for geophysical data',
     long_description="""Parser for the Aarhus Workbench XYZ format for geophysical data""",
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Part of emerald-geomodelling/emerald-installer#19. Replaces `pkg_resources.resource_stream` with `importlib.resources.files(...).open('rb')` (binary stream, verified drop-in equivalent). Version bump to 0.0.45 + CHANGES. setuptools>=81 dropped pkg_resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)